### PR TITLE
Implementação do tratamento de erros para o MapReduce/Wordcount

### DIFF
--- a/mapreduce/master.go
+++ b/mapreduce/master.go
@@ -32,11 +32,6 @@ type Master struct {
 	///////////////////////////////
 	// ADD EXTRA PROPERTIES HERE //
 	///////////////////////////////
-	// Fault Tolerance
-    failedOperationsChan chan *Operation
-    hasNewFiles bool
-    pendingOperationsCounter int
-    pendingOperationsCounterMutex sync.Mutex
 }
 
 type Operation struct {

--- a/mapreduce/master.go
+++ b/mapreduce/master.go
@@ -33,8 +33,10 @@ type Master struct {
 	// ADD EXTRA PROPERTIES HERE //
 	///////////////////////////////
 	// Fault Tolerance
-    filePathChan chan string
-    pendingOperations map[string]*Operation // Map key (string) is the operation file path;
+    failedOperationsChan chan *Operation
+    hasNewFiles bool
+    pendingOperationsCounter int
+    pendingOperationsCounterMutex sync.Mutex
 }
 
 type Operation struct {
@@ -83,8 +85,8 @@ func (master *Master) handleFailingWorkers() {
 	// YOUR CODE GOES HERE //
 	/////////////////////////
     for failedWorker := range master.failedWorkerChan {
-        master.workersMutex.Lock()
         log.Printf("Removing worker %v from master list.\n", failedWorker.id)
+        master.workersMutex.Lock()
         delete(master.workers, failedWorker.id)
         master.workersMutex.Unlock()
     }

--- a/mapreduce/master.go
+++ b/mapreduce/master.go
@@ -33,6 +33,8 @@ type Master struct {
 	// ADD EXTRA PROPERTIES HERE //
 	///////////////////////////////
 	// Fault Tolerance
+    filePathChan chan string
+    pendingOperations map[string]*Operation // Map key (string) is the operation file path;
 }
 
 type Operation struct {
@@ -80,6 +82,12 @@ func (master *Master) handleFailingWorkers() {
 	/////////////////////////
 	// YOUR CODE GOES HERE //
 	/////////////////////////
+    for failedWorker := range master.failedWorkerChan {
+        master.workersMutex.Lock()
+        log.Printf("Removing worker %v from master list.\n", failedWorker.id)
+        delete(master.workers, failedWorker.id)
+        master.workersMutex.Unlock()
+    }
 }
 
 // Handle a single connection until it's done, then closes it.

--- a/mapreduce/master_scheduler.go
+++ b/mapreduce/master_scheduler.go
@@ -17,7 +17,7 @@ func (master *Master) schedule(task *Task, proc string, filePathChan chan string
 
 	log.Printf("Scheduling %v operations\n", proc)
     
-    master.failedOperationsChan = make(chan *Operation)
+    master.failedOperationsChan = make(chan *Operation, 100)
     master.hasNewFiles = true
     
     counter := 0

--- a/mapreduce/master_scheduler.go
+++ b/mapreduce/master_scheduler.go
@@ -2,6 +2,7 @@ package mapreduce
 
 import (
 	"log"
+    "sync"
 )
 
 // Schedules map operations on remote workers. This will run until InputFilePathChan
@@ -12,38 +13,26 @@ func (master *Master) schedule(task *Task, proc string, filePathChan chan string
 	//////////////////////////////////
     
     var (
-        filePath string
+        wg sync.WaitGroup
     )
 
 	log.Printf("Scheduling %v operations\n", proc)
     
-    master.failedOperationsChan = make(chan *Operation, 100)
-    master.hasNewFiles = true
-    
     counter := 0
-    for master.hasNewFiles || master.pendingOperationsCounter>0 {
-        select {
-            case filePath, master.hasNewFiles = <- filePathChan: // If filePathChan is open, master.hasNewFiles==true;
-            if !master.hasNewFiles {
-                filePathChan = nil // "Inactivate" filePathChan in the channel selector; this will cause filePathChan to be ignored in the select loop;
-            } else {
-                master.addToPendingOperationsCounter(1) // Increment master.pendingOperationsCounter;
-                go master.runOperation(<-master.idleWorkerChan, &Operation{proc, counter, filePath})
-                counter++
-            }
-            case operation, failedOperationsChannelOpen := <- master.failedOperationsChan:
-            if failedOperationsChannelOpen {
-                go master.runOperation(<-master.idleWorkerChan, operation)
-            }
-        }
+    for filePath := range filePathChan {
+        wg.Add(1)
+        go master.runOperation(<-master.idleWorkerChan, &Operation{proc, counter, filePath}, &wg)
+        counter++
     }
+    
+    wg.Wait()
     
     log.Printf("%vx %v operations completed\n", counter, proc)
 	return counter
 }
 
 // runOperation start a single operation on a RemoteWorker and wait for it to return or fail.
-func (master *Master) runOperation(remoteWorker *RemoteWorker, operation *Operation) {
+func (master *Master) runOperation(remoteWorker *RemoteWorker, operation *Operation, wg *sync.WaitGroup) {
 	//////////////////////////////////
 	// YOU WANT TO MODIFY THIS CODE //
 	//////////////////////////////////
@@ -60,23 +49,10 @@ func (master *Master) runOperation(remoteWorker *RemoteWorker, operation *Operat
 
 	if err != nil {
 		log.Printf("Operation %v '%v' Failed. Error: %v\n", operation.proc, operation.id, err)
-        master.failedOperationsChan <- operation // (*) Re-schedule current operation for further reprocessing;
-		master.failedWorkerChan <- remoteWorker
+        master.failedWorkerChan <- remoteWorker
+        go master.runOperation(<-master.idleWorkerChan, operation, wg) // Re-schedule current operation for further reprocessing;
 	} else {
-        master.addToPendingOperationsCounter(-1) // Decrement master.pendingOperationsCounter;
         master.idleWorkerChan <- remoteWorker
+        wg.Done()
 	}
-}
-
-func (master *Master) addToPendingOperationsCounter(amount int) {
-    master.pendingOperationsCounterMutex.Lock()
-    master.pendingOperationsCounter = master.pendingOperationsCounter + amount
-    master.checkFailedOperationsChannelClosing()
-    master.pendingOperationsCounterMutex.Unlock()
-}
-
-func (master *Master) checkFailedOperationsChannelClosing() {
-    if !master.hasNewFiles && master.pendingOperationsCounter==0 { // No more failed operations to run since filePathChan doesn't have new files;
-        close(master.failedOperationsChan) // This must be executed inside de mutex block to avoid simultaneous close calls on master.failedOperationsChan;
-    }
 }


### PR DESCRIPTION
Boa tarde, Paulo.
Segue minha primeira versão para a parte 2 do Laboratório 1. Por favor, você poderia fazer uma revisão do meu código?
Aproveitando, verifiquei um comportamento estranho na execução do _framework_: quando o arquivo é pequeno e existem múltiplos _workers_, em todas as vezes que eu testei, o _master_ acabava atribuindo todos os _chunks_ para um único _worker_ enquanto todos os demais estavam no período de _sleep_ de 2 segundos. Como efeito colateral, nenhum destes _workers_ que estavam dormindo foram devidamente encerrados após o término do _master_.
Abraços,

Ballock.
