### PR TITLE
Lab1-Part2 Completo

### DIFF
--- a/mapreduce/mapreduce.go
+++ b/mapreduce/mapreduce.go
@@ -171,4 +171,5 @@ func RunWorker(task *Task, hostname string, masterHostname string, nOps int) {
 	go worker.acceptMultipleConnections()
 
 	<-worker.done
+	time.Sleep(retryDuration)
 }

--- a/mapreduce/master.go
+++ b/mapreduce/master.go
@@ -80,7 +80,17 @@ func (master *Master) handleFailingWorkers() {
 	/////////////////////////
 	// YOUR CODE GOES HERE //
 	/////////////////////////
+	var worker  *RemoteWorker
+
+	for worker = range master.failedWorkerChan {
+		log.Printf("Removing worker %v from master list.\n", worker.id)
+		master.workersMutex.Lock()
+		delete(master.workers, worker.id)
+		master.workersMutex.Unlock()
+	}
+
 }
+
 
 // Handle a single connection until it's done, then closes it.
 func (master *Master) handleConnection(conn *net.Conn) error {


### PR DESCRIPTION
O time.Sleep(retryDuration) no final de mapreduce.go serve para garantir que o worker termine de maneira suave. 
