### PR TITLE
Solução Lab1-part2 Juliana Arai

### DIFF
--- a/mapreduce/mapreduce.go
+++ b/mapreduce/mapreduce.go
@@ -171,4 +171,5 @@ func RunWorker(task *Task, hostname string, masterHostname string, nOps int) {
 	go worker.acceptMultipleConnections()
 
 	<-worker.done
+	time.Sleep(retryDuration)
 }

--- a/mapreduce/master.go
+++ b/mapreduce/master.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/rpc"
 	"sync"
+	"fmt"
 )
 
 const (
@@ -77,9 +78,12 @@ func (master *Master) acceptMultipleConnections() {
 
 // handleFailingWorkers will handle workers that fails during an operation.
 func (master *Master) handleFailingWorkers() {
-	/////////////////////////
-	// YOUR CODE GOES HERE //
-	/////////////////////////
+	for elem := range master.failedWorkerChan {
+		master.workersMutex.Lock()
+		delete(master.workers, elem.id)
+		master.workersMutex.Unlock()
+		fmt.Println("Removing worker", elem.id, "from master list.")
+    }
 }
 
 // Handle a single connection until it's done, then closes it.

--- a/mapreduce/master_scheduler.go
+++ b/mapreduce/master_scheduler.go
@@ -8,9 +8,6 @@ import (
 // Schedules map operations on remote workers. This will run until InputFilePathChan
 // is closed. If there is no worker available, it'll block.
 func (master *Master) schedule(task *Task, proc string, filePathChan chan string) int {
-	//////////////////////////////////
-	// YOU WANT TO MODIFY THIS CODE //
-	//////////////////////////////////
 
 	var (
 		wg        sync.WaitGroup
@@ -40,9 +37,6 @@ func (master *Master) schedule(task *Task, proc string, filePathChan chan string
 
 // runOperation start a single operation on a RemoteWorker and wait for it to return or fail.
 func (master *Master) runOperation(remoteWorker *RemoteWorker, operation *Operation, wg *sync.WaitGroup) {
-	//////////////////////////////////
-	// YOU WANT TO MODIFY THIS CODE //
-	//////////////////////////////////
 
 	var (
 		err  error
@@ -56,7 +50,10 @@ func (master *Master) runOperation(remoteWorker *RemoteWorker, operation *Operat
 
 	if err != nil {
 		log.Printf("Operation %v '%v' Failed. Error: %v\n", operation.proc, operation.id, err)
-		wg.Done()
+
+		worker := <-master.idleWorkerChan
+		go master.runOperation(worker, operation, wg)
+
 		master.failedWorkerChan <- remoteWorker
 	} else {
 		wg.Done()


### PR DESCRIPTION
Obs: adicionei um Sleep em mapreduce.go para eliminar a mensagem de erro "Failed to close Remote Worker. Error: read tcp 127.0.0.1:51166->127.0.0.1:5001: wsarecv: An existing connection was forcibly closed by the remote host" logo antes do Done na tela do Master, que aparecia quando eu rodava os arquivos originais no meu computador. 
